### PR TITLE
Avoid jest config warning

### DIFF
--- a/src/js/createJestConfig.js
+++ b/src/js/createJestConfig.js
@@ -15,6 +15,6 @@ export default function createJestConfig() {
         testMatch: ['<rootDir>/**/__tests__/**/*.test.js', '<rootDir>/**/*.test.js'],
         testEnvironment: 'node',
         testPathIgnorePatterns: ['/node_modules/', '<rootDir>/lib/', '<rootDir>/es/'],
-        setupTestFrameworkScriptFile: '<rootDir>/jest.setup.js',
+        setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
     };
 }

--- a/src/js/createJestConfig.js
+++ b/src/js/createJestConfig.js
@@ -1,20 +1,20 @@
-const createJestConfig = () => ({
-    collectCoverage: false,
-    collectCoverageFrom: ['src/**/*.js', 'src/**/*.jsx'],
-    coveragePathIgnorePatterns: [],
-    coverageReporters: ['cobertura', 'html', 'text'],
-    coverageThreshold: {
-        global: {
-            branches: 75,
-            functions: 80,
-            lines: 70,
-            statements: 70,
+export default function createJestConfig() {
+    return {
+        collectCoverage: false,
+        collectCoverageFrom: ['src/**/*.js', 'src/**/*.jsx'],
+        coveragePathIgnorePatterns: [],
+        coverageReporters: ['cobertura', 'html', 'text'],
+        coverageThreshold: {
+            global: {
+                branches: 75,
+                functions: 80,
+                lines: 70,
+                statements: 70,
+            },
         },
-    },
-    testMatch: ['<rootDir>/**/__tests__/**/*.test.js', '<rootDir>/**/*.test.js'],
-    testEnvironment: 'node',
-    testPathIgnorePatterns: ['/node_modules/', '<rootDir>/lib/', '<rootDir>/es/'],
-    setupTestFrameworkScriptFile: '<rootDir>/jest.setup.js',
-});
-
-export default createJestConfig;
+        testMatch: ['<rootDir>/**/__tests__/**/*.test.js', '<rootDir>/**/*.test.js'],
+        testEnvironment: 'node',
+        testPathIgnorePatterns: ['/node_modules/', '<rootDir>/lib/', '<rootDir>/es/'],
+        setupTestFrameworkScriptFile: '<rootDir>/jest.setup.js',
+    };
+}


### PR DESCRIPTION
Jest 24 warns when you use the old `setupFrameworkTestFile` config name.