### PR TITLE
Upstream `process.env.PORT` override and root singleton aliasing

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,2 @@
+// just here so the editor plugins don't get fired
+module.exports = require('prettier-config-zillow');

--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ npx create-react-styleguide new my-new-styleguide --stable
 
 Generated projects include the following npm scripts out of the box:
 
-| Script    | Description |
-| --------- | ----------- |
-| npm start | Start the styleguide server on http://localhost:6060 |
-| npm run build | Build the component library to the `lib` folder |
-| npm run build:styleguide | Build the styleguide to the `styleguide` folder |
-| npm run build:watch | Watch the `src` folder for changes and run the build script |
-| npm run clean | Clean generated folders |
-| npm run eslint | Run eslint on all .js and .jsx files in the `src` folder |
-| npm run eslint:fix | Run eslint with the `--fix` option |
-| npm test | Run unit tests |
-| npm run test:coverage | Run unit tests with code coverage |
-| npm run test:update | Update unit test snapshots |
-| npm run test:watch | Run unit tests while watching for changes |
+| Script                   | Description                                                 |
+| ------------------------ | ----------------------------------------------------------- |
+| npm start                | Start the styleguide server on http://localhost:6060        |
+| npm run build            | Build the component library to the `lib` folder             |
+| npm run build:styleguide | Build the styleguide to the `styleguide` folder             |
+| npm run build:watch      | Watch the `src` folder for changes and run the build script |
+| npm run clean            | Clean generated folders                                     |
+| npm run eslint           | Run eslint on all .js and .jsx files in the `src` folder    |
+| npm run eslint:fix       | Run eslint with the `--fix` option                          |
+| npm test                 | Run unit tests                                              |
+| npm run test:coverage    | Run unit tests with code coverage                           |
+| npm run test:update      | Update unit test snapshots                                  |
+| npm run test:watch       | Run unit tests while watching for changes                   |
 
 ## Document your styleguide
 
@@ -77,7 +77,7 @@ You can add SVG support with the [inline-react-svg](https://github.com/airbnb/ba
  };
 ```
 
- You should now be able to import and use SVGs as if they were react components!
+You should now be able to import and use SVGs as if they were react components!
 
 ## Linking multiple styleguides
 
@@ -135,17 +135,17 @@ const { createStyelguideConfig, createJestConfig } = require('create-react-style
 
 Creates a [React Styleguidist configuration object](https://react-styleguidist.js.org/docs/configuration.html) with some default configuration.
 
-* `config [object]` - A configuration object to be shallowly merged with the rest of the configuration
-* `options.styleguides [array]` - An array of CRS npm modules (the module must be installed as a dependency to your project)
-* `options.packageSection [boolean]` - Include `package.json` details as a top level section (default: `true`)
-* `options.packageSectionComponents [boolean]` - Include `components` configuration in the top-level package section (default: `false`)
-* `options.componentsSection [boolean]` - Include `components` configuration as its own separate section (default: `true`)
+-   `config [object]` - A configuration object to be shallowly merged with the rest of the configuration
+-   `options.styleguides [array]` - An array of CRS npm modules (the module must be installed as a dependency to your project)
+-   `options.packageSection [boolean]` - Include `package.json` details as a top level section (default: `true`)
+-   `options.packageSectionComponents [boolean]` - Include `components` configuration in the top-level package section (default: `false`)
+-   `options.componentsSection [boolean]` - Include `components` configuration as its own separate section (default: `true`)
 
 #### `createJestConfig(config)`
 
 Creates a [Jest configuration object](https://jestjs.io/docs/en/configuration) with some default configuration.
 
-* `config [object]` - A configuration object to be shallowly merged with the rest of the configuration
+-   `config [object]` - A configuration object to be shallowly merged with the rest of the configuration
 
 #### `DEBUG=true` environment variable
 
@@ -154,7 +154,9 @@ Both `createStyleguideConfig` and `createJestConfig` will log their results to t
 ```
 DEBUG=true node styleguide.config.js
 ```
+
 or
+
 ```
 DEBUG=true node jest.config.js
 ```

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ or
 DEBUG=true node jest.config.js
 ```
 
+### `PORT`
+
+By default, `npm start` will run the `react-styleguidist` server on its default port, `6060`. To change this, set the `PORT` environment variable to your custom value:
+
+```
+PORT=12345 npm start
+```
+
 ## Under the covers
 
 `create-react-styleguide` leverages [react-styleguidist](https://react-styleguidist.js.org/) under the covers for its living style guide.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Require the module:
 const { createStyelguideConfig, createJestConfig } = require('create-react-styleguide');
 ```
 
-#### `createStyleguideConfig(config, options)`
+### `createStyleguideConfig(config, options)`
 
 Creates a [React Styleguidist configuration object](https://react-styleguidist.js.org/docs/configuration.html) with some default configuration.
 
@@ -141,15 +141,17 @@ Creates a [React Styleguidist configuration object](https://react-styleguidist.j
 -   `options.packageSectionComponents [boolean]` - Include `components` configuration in the top-level package section (default: `false`)
 -   `options.componentsSection [boolean]` - Include `components` configuration as its own separate section (default: `true`)
 
-#### `createJestConfig(config)`
+### `createJestConfig(config)`
 
 Creates a [Jest configuration object](https://jestjs.io/docs/en/configuration) with some default configuration.
 
 -   `config [object]` - A configuration object to be shallowly merged with the rest of the configuration
 
-#### `DEBUG=true` environment variable
+## Environment Variables
 
-Both `createStyleguideConfig` and `createJestConfig` will log their results to the console when the `DEBUG=true` environment variable is set. A quick way to see the configuration these functions are creating is to run the following:
+### `DEBUG`
+
+Both `createStyleguideConfig` and `createJestConfig` will log their results to the console when the `DEBUG` environment variable is set to any non-empty value (such as `true` or `1`). A quick way to see the configuration these functions are creating is to run the following:
 
 ```
 DEBUG=true node styleguide.config.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -9742,6 +9742,21 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
+    "resolve-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
+      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9002,6 +9002,17 @@
         }
       }
     },
+    "react": {
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.10.1.tgz",
+      "integrity": "sha512-2bisHwMhxQ3XQz4LiJJwG3360pY965pTl/MRrZYxIBKVj4fOHoDs5aZAkYXGxDRO1Li+SyjTAilQEbOmtQJHzA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-dev-utils": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-6.1.1.tgz",
@@ -9146,6 +9157,18 @@
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
           "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
         }
+      }
+    },
+    "react-dom": {
+      "version": "16.10.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.10.1.tgz",
+      "integrity": "sha512-SmM4ZW0uug0rn95U8uqr52I7UdNf6wdGLeXDmNLfg3y5q5H9eAbdjF5ubQc3bjDyRrvdAB2IKG7X0GzSpnn5Mg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.16.1"
       }
     },
     "react-error-overlay": {
@@ -9855,6 +9878,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "scheduler": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.16.1.tgz",
+      "integrity": "sha512-MIuie7SgsqMYOdCXVFZa8SKoNorJZUWHW8dPgto7uEHn1lX3fg2Gu0TzgK8USj76uxV7vB5eRMnZs/cdEHg+cg==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "schema-utils": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "prettier": "^1.18.2",
     "react-styleguidist": "^9.1.11",
     "resolve": "^1.11.1",
+    "resolve-pkg": "^2.0.0",
     "rimraf": "^2.6.3",
     "run-parallel": "1.1.9",
     "run-series": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "babel-preset-zillow": "^4.1.0",
     "eslint-plugin-zillow": "^3.3.1",
     "husky": "^3.0.0",
+    "react": "^16.10.1",
+    "react-dom": "^16.10.1",
     "standard-version": "^6.0.1"
   },
   "repository": {

--- a/src/js/__tests__/createStyleguideConfig.test.js
+++ b/src/js/__tests__/createStyleguideConfig.test.js
@@ -1,5 +1,10 @@
 const { createStyleguideConfig } = require('../..');
 
+afterEach(() => {
+    // this value should not bleed between tests
+    delete process.env.creatingStyleguideConfig;
+});
+
 describe('config.serverPort', () => {
     afterEach(() => {
         delete process.env.PORT;
@@ -12,5 +17,20 @@ describe('config.serverPort', () => {
 
     it('is not set when process.env.PORT does not exist', () => {
         expect(createStyleguideConfig()).not.toHaveProperty('serverPort');
+    });
+});
+
+describe('webpackConfig.resolve.alias', () => {
+    it('is configured at root level', () => {
+        expect(createStyleguideConfig()).toHaveProperty('webpackConfig.resolve.alias', {
+            'react': expect.stringMatching(/node_modules\/react$/),
+            'react-dom': expect.stringMatching(/node_modules\/react-dom$/),
+            // missing deps (e.g., styled-components) are merely skipped
+        });
+    });
+
+    it('is not configured in nested executions', () => {
+        process.env.creatingStyleguideConfig = '1';
+        expect(createStyleguideConfig()).not.toHaveProperty('webpackConfig.resolve.alias');
     });
 });

--- a/src/js/__tests__/createStyleguideConfig.test.js
+++ b/src/js/__tests__/createStyleguideConfig.test.js
@@ -1,0 +1,16 @@
+const { createStyleguideConfig } = require('../..');
+
+describe('config.serverPort', () => {
+    afterEach(() => {
+        delete process.env.PORT;
+    });
+
+    it('is set when process.env.PORT exists', () => {
+        process.env.PORT = '12345';
+        expect(createStyleguideConfig()).toHaveProperty('serverPort', 12345);
+    });
+
+    it('is not set when process.env.PORT does not exist', () => {
+        expect(createStyleguideConfig()).not.toHaveProperty('serverPort');
+    });
+});

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -155,25 +155,26 @@ module.exports = (config, options) => {
     process.env.creatingStyleguideConfig = process.env.creatingStyleguideConfig || 0;
     process.env.creatingStyleguideConfig += 1;
 
-    const styleguideConfig = linkStyleguides(
-        {
-            webpackConfig: {
-                module: {
-                    rules: [
-                        {
-                            test: /\.jsx?$/,
-                            include: [path.join(process.cwd(), 'src')],
-                            use: {
-                                loader: 'babel-loader',
-                            },
-                        },
-                    ],
+    const webpackConfig = {
+        module: {
+            rules: [
+                {
+                    test: /\.jsx?$/,
+                    include: [path.join(process.cwd(), 'src')],
+                    use: {
+                        loader: 'babel-loader',
+                    },
                 },
-            },
-            ...config,
+            ],
         },
-        options
-    );
+    };
+
+    const baseConfig = {
+        webpackConfig,
+        ...config,
+    };
+
+    const styleguideConfig = linkStyleguides(baseConfig, options);
 
     if (process.env.DEBUG) {
         // eslint-disable-next-line no-console

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -174,6 +174,11 @@ module.exports = (config, options) => {
         ...config,
     };
 
+    if (process.env.PORT) {
+        // the default is 6060, and provided upstream
+        baseConfig.serverPort = Number.parseInt(process.env.PORT, 10);
+    }
+
     const styleguideConfig = linkStyleguides(baseConfig, options);
 
     if (process.env.DEBUG) {

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const resolvePkg = require('resolve-pkg');
 
 const COMPONENTS = 'src/components/**/[A-Z]*.{js,jsx,ts,tsx}';
 
@@ -176,6 +177,22 @@ module.exports = (config, options) => {
             ],
         },
     };
+
+    // only the root should alias singletons
+    if (process.env.creatingStyleguideConfig === '1') {
+        webpackConfig.resolve = {
+            alias: ['react', 'react-dom', 'styled-components'].reduce((acc, name) => {
+                // resolvePkg does not throw if it cannot resolve, merely returns undefined
+                const realPath = resolvePkg(name);
+
+                if (realPath) {
+                    acc[name] = realPath;
+                }
+
+                return acc;
+            }, {}),
+        };
+    }
 
     const baseConfig = {
         webpackConfig,

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -13,6 +13,14 @@ const getAuthor = author => {
     return false;
 };
 
+const getCurrentDepth = () => {
+    // process.env values are _always_ stored as strings, regardless of input type
+    if (process.env.creatingStyleguideConfig) {
+        return Number.parseInt(process.env.creatingStyleguideConfig, 10);
+    }
+    return 0;
+};
+
 const getPackageInfo = pkg => ({
     name: pkg.name,
     description: `| Version | Homepage | Author |\n| - | - | - |\n| ${
@@ -73,6 +81,7 @@ const linkStyleguides = (config, opts) => {
         ...(config.sections ? config.sections : []),
         ...(componentsSection ? [componentsSection] : []),
     ];
+
     if (options.packageSection) {
         // eslint-disable-next-line global-require, zillow/import/no-dynamic-require
         const pkg = require(path.join(workingDir, 'package.json'));
@@ -93,7 +102,7 @@ const linkStyleguides = (config, opts) => {
 
     // Only link styleguides one level deep,
     // i.e. do not link styleguides from a linked styleguide
-    if (process.env.creatingStyleguideConfig > 2) {
+    if (getCurrentDepth() > 2) {
         styleguides = [];
     }
 
@@ -152,8 +161,7 @@ const linkStyleguides = (config, opts) => {
 
 module.exports = (config, options) => {
     // Monitor and limit the depth at which we link styleguides to direct children only.
-    process.env.creatingStyleguideConfig = process.env.creatingStyleguideConfig || 0;
-    process.env.creatingStyleguideConfig += 1;
+    process.env.creatingStyleguideConfig = `${getCurrentDepth() + 1}`;
 
     const webpackConfig = {
         module: {

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -179,7 +179,7 @@ module.exports = (config, options) => {
     };
 
     // only the root should alias singletons
-    if (process.env.creatingStyleguideConfig === '1') {
+    if (getCurrentDepth() === 1) {
         webpackConfig.resolve = {
             alias: ['react', 'react-dom', 'styled-components'].reduce((acc, name) => {
                 // resolvePkg does not throw if it cannot resolve, merely returns undefined


### PR DESCRIPTION
```sh
# starts server on default port 6060
npx create-react-styleguide script start

# starts server on port 12345
PORT=12345 npx create-react-styleguide script start
```

Always aliasing singletons (like `react` & `styled-components`) helps avoid problems during `npm link`-ed development, as well as minimizing the potential for duplicate modules in the resulting bundle.