### PR TITLE
IE 11 Support + circular-dependencies-plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,12 @@
 module.exports = {
-    presets: [['zillow', { modules: false }]],
-    env: {
-        cjs: {
-            presets: ['zillow'],
-        },
-        test: {
-            presets: ['zillow'],
-        },
-    },
+    presets: [
+        [
+            'babel-preset-zillow',
+            {
+                targets: {
+                    node: 'current',
+                },
+            },
+        ],
+    ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 const { createJestConfig } = require('./src');
 
 const config = createJestConfig();
-config.testPathIgnorePatterns.push('<rootDir>/templates/');
 
-module.exports = config;
+module.exports = {
+    ...config,
+    testPathIgnorePatterns: [...config.testPathIgnorePatterns, '<rootDir>/templates/'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,7 @@ const config = createJestConfig();
 
 module.exports = {
     ...config,
+    // TODO: test the CLI properly
+    coveragePathIgnorePatterns: ['<rootDir>/src/bin/'],
     testPathIgnorePatterns: [...config.testPathIgnorePatterns, '<rootDir>/templates/'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2556,6 +2556,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "circular-dependency-plugin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz",
+      "integrity": "sha512-7p4Kn/gffhQaavNfyDFg7LS5S/UT1JAjyGd4UqR2+jzoYF02eDkj0Ec3+48TsIa4zghjLY87nQHIh/ecK9qLdw=="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3439,6 +3439,12 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
+    },
     "css-initials": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/css-initials/-/css-initials-0.2.0.tgz",
@@ -10873,10 +10879,159 @@
         }
       }
     },
+    "tacks": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tacks/-/tacks-1.3.0.tgz",
+      "integrity": "sha512-jpQhdKlYom3cohYmjSYqny9Ie8QJr6OYe4wdyu/nEgfiIQpOvLwq72vCRucg9+jUlnspnKvL5HASnmkxOf3DXQ==",
+      "dev": true,
+      "requires": {
+        "@iarna/cli": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "@iarna/cli": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "^7.0.5"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+    },
+    "temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0=",
+      "dev": true
+    },
+    "tempy": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.3.0.tgz",
+      "integrity": "sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==",
+      "dev": true,
+      "requires": {
+        "temp-dir": "^1.0.0",
+        "type-fest": "^0.3.1",
+        "unique-string": "^1.0.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+          "dev": true
+        }
+      }
     },
     "terser": {
       "version": "4.3.4",
@@ -11325,6 +11480,15 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unist-util-is": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "acorn": "^6.3.0",
     "babel-loader": "^8.0.6",
     "chalk": "^2.4.2",
+    "circular-dependency-plugin": "^5.2.0",
     "copy-template-dir": "1.4.0",
     "cross-spawn": "6.0.5",
     "eslint": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,9 @@
     "husky": "^3.0.8",
     "react": "^16.10.2",
     "react-dom": "^16.10.2",
-    "standard-version": "^6.0.1"
+    "standard-version": "^6.0.1",
+    "tacks": "^1.3.0",
+    "tempy": "^0.3.0"
   },
   "repository": {
     "type": "git",

--- a/src/js/__tests__/createStyleguideConfig.test.js
+++ b/src/js/__tests__/createStyleguideConfig.test.js
@@ -44,7 +44,7 @@ describe('webpackConfig.resolve.alias', () => {
     });
 
     it('is not configured in nested executions', () => {
-        process.env.creatingStyleguideConfig = '1';
+        process.env.creatingStyleguideConfig = __dirname;
         expect(createStyleguideConfig()).not.toHaveProperty('webpackConfig.resolve.alias');
     });
 });
@@ -66,7 +66,7 @@ describe('IE 11 support for styleguidist artifacts', () => {
     });
 
     it('is not configured in nested executions', () => {
-        process.env.creatingStyleguideConfig = '1';
+        process.env.creatingStyleguideConfig = __dirname;
         const { webpackConfig } = createStyleguideConfig();
         expect(webpackConfig.module.rules).toHaveLength(1);
     });
@@ -91,7 +91,7 @@ describe('circular-dependency-plugin', () => {
     });
 
     it('is not configured in nested executions', () => {
-        process.env.creatingStyleguideConfig = '1';
+        process.env.creatingStyleguideConfig = __dirname;
         const { webpackConfig } = createStyleguideConfig();
         expect(webpackConfig.plugins).toStrictEqual([]);
     });

--- a/src/js/__tests__/createStyleguideConfig.test.js
+++ b/src/js/__tests__/createStyleguideConfig.test.js
@@ -34,3 +34,26 @@ describe('webpackConfig.resolve.alias', () => {
         expect(createStyleguideConfig()).not.toHaveProperty('webpackConfig.resolve.alias');
     });
 });
+
+describe('IE 11 support for styleguidist artifacts', () => {
+    it('is configured at root level', () => {
+        const { webpackConfig } = createStyleguideConfig();
+        expect(webpackConfig.module.rules[1]).toHaveProperty('use.options.presets', [
+            [
+                '@babel/preset-env',
+                {
+                    modules: 'commonjs',
+                    targets: {
+                        ie: '11',
+                    },
+                },
+            ],
+        ]);
+    });
+
+    it('is not configured in nested executions', () => {
+        process.env.creatingStyleguideConfig = '1';
+        const { webpackConfig } = createStyleguideConfig();
+        expect(webpackConfig.module.rules).toHaveLength(1);
+    });
+});

--- a/src/js/__tests__/createStyleguideConfig.test.js
+++ b/src/js/__tests__/createStyleguideConfig.test.js
@@ -1,22 +1,67 @@
+const path = require('path');
+const Tacks = require('tacks');
+const tempy = require('tempy');
 const { createStyleguideConfig } = require('../..');
 
-// normalize cwd in snapshots
-const CWD_REGEXP = new RegExp(process.cwd());
+const { Dir, File, Symlink } = Tacks;
+
+// normalize cwd in snapshots (from lazy root _or_ fixture tempdir)
+const ROOT_CWD = process.cwd();
+const ROOT_CWD_REGEXP = new RegExp(ROOT_CWD);
+
+// tempy creates subdirectories with hexadecimal names that are 32 characters long
+// the excluded quotes are due to other snapshot serializers mutating the raw input
+const TEMP_DIR_REGEXP = /([^\s"]*[\\/][0-9a-f]{32})([^\s"]*)/g;
 
 expect.addSnapshotSerializer({
     test(val) {
-        return typeof val === 'string' && CWD_REGEXP.test(val);
+        return typeof val === 'string' && (ROOT_CWD_REGEXP.test(val) || TEMP_DIR_REGEXP.test(val));
     },
     serialize(val, config, indentation, depth) {
-        const str = val.replace(CWD_REGEXP, '__CWD__');
+        const str = val
+            .replace(ROOT_CWD_REGEXP, '<CWD>')
+            .replace(TEMP_DIR_REGEXP, (match, cwd, subPath) => path.join('<CWD>', subPath));
+
         // top-level strings don't need quotes, but nested ones do (object properties, etc)
         return depth ? `"${str}"` : str;
     },
 });
 
+function setup({ node_modules, ...root } = {}) {
+    const cwd = tempy.directory();
+
+    new Tacks(
+        Dir({
+            ...root,
+            node_modules: Dir({
+                // eslint-disable-next-line camelcase
+                ...node_modules,
+                'create-react-styleguide': Dir({
+                    'package.json': File({
+                        name: 'create-react-styleguide',
+                        main: 'src/index.js',
+                    }),
+                    // facilitate node_modules config files requiring 'create-react-styleguide'
+                    'src': Symlink(
+                        path.relative(
+                            path.join(cwd, 'node_modules/create-react-styleguide'),
+                            path.join(ROOT_CWD, 'src')
+                        )
+                    ),
+                }),
+            }),
+        })
+    ).create(cwd);
+
+    process.chdir(cwd);
+}
+
 afterEach(() => {
     // this value should not bleed between tests
     delete process.env.creatingStyleguideConfig;
+
+    // always restore original cwd
+    process.chdir(ROOT_CWD);
 });
 
 describe('config.serverPort', () => {
@@ -80,7 +125,7 @@ describe('circular-dependency-plugin', () => {
             CircularDependencyPlugin {
               "options": Object {
                 "allowAsyncCycles": false,
-                "cwd": "__CWD__",
+                "cwd": "<CWD>",
                 "exclude": /node_modules/,
                 "failOnError": true,
                 "include": /\\.\\*/,
@@ -94,5 +139,130 @@ describe('circular-dependency-plugin', () => {
         process.env.creatingStyleguideConfig = __dirname;
         const { webpackConfig } = createStyleguideConfig();
         expect(webpackConfig.plugins).toStrictEqual([]);
+    });
+});
+
+describe('config.sections', () => {
+    it('resolves parent component globs relative to cwd', () => {
+        setup({
+            'package.json': File({
+                name: 'my-default-styleguide',
+                version: '1.0.0',
+                homepage: 'https://my-default-styleguide.com/',
+            }),
+            // no root styleguide.config.js necessary because we're calling it below
+        });
+
+        const { sections } = createStyleguideConfig();
+
+        // a single top-level section always has an empty object pushed onto it
+        // @see https://github.com/styleguidist/react-styleguidist/issues/1137
+        expect(sections).toMatchInlineSnapshot(`
+            Array [
+              Object {
+                "description": "| Version | Homepage | Author |
+            | - | - | - |
+            | 1.0.0 | https://my-default-styleguide.com/ | not specified |",
+                "name": "my-default-styleguide",
+                "sections": Array [
+                  Object {
+                    "components": "src/components/**/[A-Z]*.{js,jsx,ts,tsx}",
+                    "name": "Components",
+                  },
+                ],
+              },
+              Object {},
+            ]
+        `);
+    });
+
+    describe('with linked styleguides', () => {
+        it('resolves nested component globs absolutely', () => {
+            setup({
+                'node_modules': {
+                    'my-linked-styleguide': Dir({
+                        'package.json': File({
+                            name: 'my-linked-styleguide',
+                            version: '2.0.0',
+                            author: {
+                                name: 'Linked Styleguide Author',
+                            },
+                        }),
+                        // src dir is necessary due to fs.realpathSync() for webpack config
+                        'src': Dir(),
+                        'styleguide.config.js': File(`
+                            const { createStyleguideConfig } = require('create-react-styleguide');
+
+                            module.exports = createStyleguideConfig({
+                                sections: [{
+                                    name: 'Linked Introduction',
+                                    content: 'docs/introduction.md',
+                                }, {
+                                    name: 'Linked Components',
+                                    components: [
+                                        'src/components/**/[A-Z]*.{js,jsx}',
+                                        'packages/**/src/[A-Z]*.{js,jsx}',
+                                    ],
+                                }],
+                            }, {
+                                styleguides: ['my-parent-styleguide'],
+                                componentsSection: false,
+                            });
+                        `),
+                    }),
+                },
+                'package.json': File({
+                    name: 'my-parent-styleguide',
+                    version: '1.0.0',
+                    homepage: 'https://my-parent-styleguide.com/',
+                    author: 'Parent Styleguide Author',
+                }),
+            });
+
+            const { sections } = createStyleguideConfig(
+                {
+                    sections: [
+                        {
+                            name: 'Top-Level Introduction',
+                            content: 'docs/introduction.md',
+                        },
+                    ],
+                },
+                {
+                    styleguides: ['my-linked-styleguide'],
+                    packageSection: false,
+                    componentsSection: false,
+                }
+            );
+
+            // no empty object is appended when more than one section is configured
+            expect(sections).toMatchInlineSnapshot(`
+                Array [
+                  Object {
+                    "content": "docs/introduction.md",
+                    "name": "Top-Level Introduction",
+                  },
+                  Object {
+                    "description": "| Version | Homepage | Author |
+                | - | - | - |
+                | 2.0.0 | not specified | Linked Styleguide Author |",
+                    "name": "my-linked-styleguide",
+                    "sections": Array [
+                      Object {
+                        "content": "<CWD>/node_modules/my-linked-styleguide/docs/introduction.md",
+                        "name": "Linked Introduction",
+                      },
+                      Object {
+                        "components": Array [
+                          "<CWD>/node_modules/my-linked-styleguide/src/components/**/[A-Z]*.{js,jsx}",
+                          "<CWD>/node_modules/my-linked-styleguide/packages/**/src/[A-Z]*.{js,jsx}",
+                        ],
+                        "name": "Linked Components",
+                      },
+                    ],
+                  },
+                ]
+            `);
+        });
     });
 });

--- a/src/js/__tests__/createStyleguideConfig.test.js
+++ b/src/js/__tests__/createStyleguideConfig.test.js
@@ -177,7 +177,7 @@ describe('config.sections', () => {
     });
 
     describe('with linked styleguides', () => {
-        it('resolves nested component globs absolutely', () => {
+        it('resolves nested component globs relative to parent cwd', () => {
             setup({
                 'node_modules': {
                     'my-linked-styleguide': Dir({
@@ -249,13 +249,13 @@ describe('config.sections', () => {
                     "name": "my-linked-styleguide",
                     "sections": Array [
                       Object {
-                        "content": "<CWD>/node_modules/my-linked-styleguide/docs/introduction.md",
+                        "content": "node_modules/my-linked-styleguide/docs/introduction.md",
                         "name": "Linked Introduction",
                       },
                       Object {
                         "components": Array [
-                          "<CWD>/node_modules/my-linked-styleguide/src/components/**/[A-Z]*.{js,jsx}",
-                          "<CWD>/node_modules/my-linked-styleguide/packages/**/src/[A-Z]*.{js,jsx}",
+                          "node_modules/my-linked-styleguide/src/components/**/[A-Z]*.{js,jsx}",
+                          "node_modules/my-linked-styleguide/packages/**/src/[A-Z]*.{js,jsx}",
                         ],
                         "name": "Linked Components",
                       },

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -252,6 +252,12 @@ module.exports = (config, options) => {
             isRootConfig(),
             styleguideConfig
         );
+
+        // inject trailing newline when config is nested
+        if (!isRootConfig()) {
+            // eslint-disable-next-line no-console
+            console.log();
+        }
     }
 
     return styleguideConfig;

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -37,14 +37,20 @@ const resolvePaths = (section, basePath) => {
         if (val) {
             if (typeof val === 'string' && val.charAt(0) !== '/') {
                 // eslint-disable-next-line no-param-reassign
-                section[key] = path.join(basePath, val);
+                section[key] = path.join(
+                    path.relative(process.env.creatingStyleguideConfig, basePath),
+                    val
+                );
             }
             // components key supports an array of paths
             if (Array.isArray(val)) {
                 for (let i = 0; i < val.length; i += 1) {
                     if (typeof val[i] === 'string' && val[i].charAt(0) !== '/') {
                         // eslint-disable-next-line no-param-reassign
-                        val[i] = path.join(basePath, val[i]);
+                        val[i] = path.join(
+                            path.relative(process.env.creatingStyleguideConfig, basePath),
+                            val[i]
+                        );
                     }
                 }
             }

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const resolvePkg = require('resolve-pkg');
+const CircularDependencyPlugin = require('circular-dependency-plugin');
 
 const COMPONENTS = 'src/components/**/[A-Z]*.{js,jsx,ts,tsx}';
 
@@ -176,9 +177,10 @@ module.exports = (config, options) => {
                 },
             ],
         },
+        plugins: [],
     };
 
-    // only the root should alias singletons
+    // only the root should alias singletons or check circularity
     if (getCurrentDepth() === 1) {
         // IE 11 support for styleguidist-generated artifacts
         webpackConfig.module.rules.push({
@@ -214,6 +216,14 @@ module.exports = (config, options) => {
                 return acc;
             }, {}),
         };
+
+        webpackConfig.plugins.push(
+            new CircularDependencyPlugin({
+                exclude: /node_modules/,
+                failOnError: true,
+                cwd: process.cwd(),
+            })
+        );
     }
 
     const baseConfig = {

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -110,8 +110,8 @@ const linkStyleguides = (config, opts) => {
         styleguides = [];
     }
 
-    styleguides.forEach(module => {
-        const modulePath = path.join(workingDir, `node_modules/${module}`);
+    styleguides.forEach(moduleName => {
+        const modulePath = path.join(workingDir, `node_modules/${moduleName}`);
         const configPath = path.join(modulePath, 'styleguide.config.js');
 
         let styleguideConfig;
@@ -130,7 +130,7 @@ const linkStyleguides = (config, opts) => {
         if (!styleguideConfig) {
             // eslint-disable-next-line no-console
             console.warn(
-                `Warning: could not load configuration for module "${module}", make sure the module is installed and styleguide.config.js is configured correctly\n`
+                `Warning: could not load configuration for module "${moduleName}", make sure the module is installed and styleguide.config.js is configured correctly\n`
             );
             return;
         }

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -150,7 +150,7 @@ const linkStyleguides = (config, opts) => {
     }
 
     // https://github.com/styleguidist/react-styleguidist/issues/1137
-    if (sections.length === 1) {
+    if (isRootConfig() && sections.length === 1) {
         config.sections.push({});
     }
 

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -180,6 +180,28 @@ module.exports = (config, options) => {
 
     // only the root should alias singletons
     if (getCurrentDepth() === 1) {
+        // IE 11 support for styleguidist-generated artifacts
+        webpackConfig.module.rules.push({
+            test: /\.jsx?$/,
+            include: /node_modules\/(?=(acorn-jsx|estree-walker|regexpu-core|unicode-match-property-ecmascript|unicode-match-property-value-ecmascript|react-dev-utils|ansi-styles|ansi-regex|chalk|strip-ansi)\/).*/,
+            use: {
+                loader: 'babel-loader',
+                options: {
+                    presets: [
+                        [
+                            '@babel/preset-env',
+                            {
+                                modules: 'commonjs',
+                                targets: {
+                                    ie: '11',
+                                },
+                            },
+                        ],
+                    ],
+                },
+            },
+        });
+
         webpackConfig.resolve = {
             alias: ['react', 'react-dom', 'styled-components'].reduce((acc, name) => {
                 // resolvePkg does not throw if it cannot resolve, merely returns undefined

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -236,9 +236,18 @@ module.exports = (config, options) => {
 
     const styleguideConfig = linkStyleguides(baseConfig, options);
 
+    // istanbul ignore next: irrelevant
     if (process.env.DEBUG) {
         // eslint-disable-next-line no-console
-        console.log('createStyleguideConfig object:', JSON.stringify(styleguideConfig, null, 4));
+        console.log('\ncreateStyleguideConfig (isRootConfig = %j)', isRootConfig());
+
+        // eslint-disable-next-line no-console
+        console.dir(styleguideConfig, {
+            breakLength: Infinity,
+            compact: false,
+            colors: true,
+            depth: 10,
+        });
     }
 
     return styleguideConfig;

--- a/src/js/createStyleguideConfig.js
+++ b/src/js/createStyleguideConfig.js
@@ -238,16 +238,20 @@ module.exports = (config, options) => {
 
     // istanbul ignore next: irrelevant
     if (process.env.DEBUG) {
-        // eslint-disable-next-line no-console
-        console.log('\ncreateStyleguideConfig (isRootConfig = %j)', isRootConfig());
-
-        // eslint-disable-next-line no-console
-        console.dir(styleguideConfig, {
+        // eslint-disable-next-line global-require
+        require('util').inspect.defaultOptions = {
             breakLength: Infinity,
             compact: false,
-            colors: true,
+            // 'colors' defaults to true when TTY is interactive
             depth: 10,
-        });
+        };
+
+        // eslint-disable-next-line no-console
+        console.log(
+            'createStyleguideConfig (isRootConfig = %j)\n%O',
+            isRootConfig(),
+            styleguideConfig
+        );
     }
 
     return styleguideConfig;


### PR DESCRIPTION
In the process of testing this in various consumers locally, I found out my previous integer incrementing scheme was complete clown-shoes, counting up as many times as one had linked styleguides (eeek).

Also during this testing I made the debug output purty (colors, better serialization of JS, etc). Nobody could use it for the "actual" config anyway, so it's better to have a representation closer to what it _actually_ is (webpack class instances, regexes, etc) instead of a "pure" JSON blob that strips out anything that isn't a string or number.